### PR TITLE
using v0.40.0 multiarch upstream images for prometheus

### DIFF
--- a/namespaces/observability/prometheus-operator/prometheus-operator.yaml
+++ b/namespaces/observability/prometheus-operator/prometheus-operator.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: prometheus-operator
-    version: 8.13.8
+    version: 8.15.6
   values:
     fullnameOverride: 'z'
     prometheusOperator:
@@ -23,8 +23,8 @@ spec:
       manageCrds: true
       createCustomResource: true
       image:
-        repository: raspbernetes/prometheus-operator
-        tag: v0.38.1
+        repository: quay.io/coreos/prometheus-operator
+        tag: v0.40.0
         pullPolicy: Always
       tlsProxy:
         image:
@@ -39,8 +39,8 @@ spec:
         repository: jimmidyson/configmap-reload
         tag: v0.3.0
       prometheusConfigReloaderImage:
-        repository: raspbernetes/prometheus-operator-config-reloader
-        tag: v0.38.1
+        repository: quay.io/coreos/prometheus-config-reloader
+        tag: v0.40.0
     alertmanager:
       enabled: true
     grafana:


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Update to use the upstream provided images now they're supporting multi-arch images.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.