### PR TITLE
adding security fix for self-hosted runners

### DIFF
--- a/.github/workflows/cluster.yml
+++ b/.github/workflows/cluster.yml
@@ -1,6 +1,6 @@
 name: cluster
 
-on: ['pull_request']
+on: ['push']
 
 jobs:
   validate:


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

As documented:

https://github.community/t/self-hosted-runner-security-with-public-repositories/17860

https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners#self-hosted-runner-security-with-public-repositories

It is not safe to run self-hosted runners on a `pull_request` trigger.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [x] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.