### PR TITLE
Add podmonitor for gotk components

### DIFF
--- a/namespaces/gotk-system/podmonitor.yaml
+++ b/namespaces/gotk-system/podmonitor.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: helm-controller
+  namespace: gotk-system
+spec:
+  selector:
+    matchLabels:
+      app: helm-controller
+  podMetricsEndpoints:
+    - port: http-prom
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kustomize-controller
+  namespace: gotk-system
+spec:
+  selector:
+    matchLabels:
+      app: kustomize-controller
+  podMetricsEndpoints:
+    - port: http-prom
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: notification-controller
+  namespace: gotk-system
+spec:
+  selector:
+    matchLabels:
+      app: notification-controller
+  podMetricsEndpoints:
+    - port: http-prom
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: source-controller
+  namespace: gotk-system
+spec:
+  selector:
+    matchLabels:
+      app: source-controller
+  podMetricsEndpoints:
+    - port: http-prom


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Each toolkit component supports a `/metrics` endpoint. Importing the dashboards directly from the toolkit repository and using them with a pre-existing Prometheus and Grafana means creating the PodMonitor custom resource explicitly (default is to install it with Prometheus & Grafana as part of the gotk install/create operation).

## Checklist

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #119

## Notes

Add special notes for your reviewer here.
