### PR TITLE
Update istio to v1.7.3 and configure REGISRY_ONLY mode

### DIFF
--- a/namespaces/istio-system/istio/istio-1.7.3.yaml
+++ b/namespaces/istio-system/istio/istio-1.7.3.yaml
@@ -208,10 +208,12 @@ spec:
             maxUnavailable: 25%
   hub: docker.io/querycapistio
   meshConfig:
+    outboundTrafficPolicy:
+      mode: REGISTRY_ONLY
     defaultConfig:
       proxyMetadata: {}
     enablePrometheusMerge: true
-  tag: 1.7.2
+  tag: 1.7.3
   values:
     base:
       enableCRDTemplates: false

--- a/namespaces/istio-system/istio/serviceentry.yaml
+++ b/namespaces/istio-system/istio/serviceentry.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: googleapis-se
+  namespace: 'istio-system'
+spec:
+  hosts:
+    - '*.googleapis.com'
+  ports:
+    - name: https-googleapis
+      number: 443
+      protocol: HTTPS
+  resolution: NONE
+  location: MESH_EXTERNAL


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Upgrade istio to version 1.7.3 and configure `meshConfig.outboundTrafficPolicy.mode=ALLOW_ANY`.

As part of setting `REGISTRY_ONLY` mode, a service entry has been added for the googleapis connection required for `velero`.

## Checklist

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
