### PR TITLE
Adding pre-commit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Please provide a description of what this PR is for.
 
 - [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
 - [ ] Provide a title or release-note blurb suitable for the release notes.
+- [ ] All pre-commit hook validation passed successfully.
 - [ ] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
 - [ ] All workflow validation and compliance checks are passing.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
   <a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fraspbernetes%2Fk8s-gitops?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fraspbernetes%2Fk8s-gitops.svg?type=shield"/></a>
   <a href="https://github.com/raspbernetes/k8s-gitops/actions" alt="Build"><img src="https://github.com/raspbernetes/k8s-gitops/workflows/build/badge.svg" /></a>
   <a href="https://discord.gg/mey6zUn"><img src="https://img.shields.io/badge/discord-chat-7289DA.svg" alt="Discord"></a>
-  <a href="https://kubernetes.io/" alt="k8s"><img src="https://img.shields.io/badge/k8s-v1.19.2-orange" /></a>
+  <a href="https://kubernetes.io/" alt="k8s"><img src="https://img.shields.io/badge/k8s-v1.19.3-orange" /></a>
   <a href="https://github.com/raspbernetes/k8s-gitops/graphs/contributors"><img src="https://img.shields.io/github/contributors/raspbernetes/k8s-gitops.svg" alt="Contributors"></a>
   <a href="https://github.com/raspbernetes/k8s-gitops/issues"><img src="https://img.shields.io/github/issues-raw/raspbernetes/k8s-gitops.svg" alt="Open Issues"></a>
   <a href="https://github.com/raspbernetes/k8s-gitops"><img src="https://img.shields.io/github/stars/raspbernetes/k8s-gitops?style=social.svg" alt="Stars"></a>
   <a href="https://github.com/raspbernetes/k8s-gitops/commits/main" alt="last commit"><img src="https://img.shields.io/github/last-commit/raspbernetes/k8s-gitops?color=purple" /></a>
+  <a href="https://github.com/pre-commit/pre-commit" alt="pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white" /></a>
 </div>
 
 # Overview


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Adding pre-commit hook to do some client-side validation prior to CI detection to save local dev time.

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
