### PR TITLE
Adding service monitors for thanos

### DIFF
--- a/cluster/observability/thanos/servicemonitor.yaml
+++ b/cluster/observability/thanos/servicemonitor.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: compact
+  namespace: observability
+spec:
+  jobLabel: thanos-compact
+  endpoints:
+    - port: http
+      interval: 15s
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compact
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rule
+  namespace: observability
+spec:
+  jobLabel: thanos-rule
+  endpoints:
+    - port: http
+      interval: 15s
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rule
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: query
+  namespace: observability
+spec:
+  jobLabel: thanos-query
+  endpoints:
+    - port: http
+      interval: 15s
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sidecar
+  namespace: observability
+spec:
+  jobLabel: thanos-sidecar
+  endpoints:
+    - port: http
+      interval: 15s
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: sidecar
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: store
+  namespace: observability
+spec:
+  jobLabel: thanos-store
+  endpoints:
+    - port: http
+      interval: 15s
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Configure service monitors outside of the thanos charts to avoid the chart having a direct dependency on other charts where possible.

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All pre-commit hook validation passed successfully.
- [x] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #142

## Notes

Add special notes for your reviewer here.
