### PR TITLE
Update kube-prometheus-stack removing nginx ingress objects

### DIFF
--- a/cluster/observability/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/cluster/observability/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -29,7 +29,7 @@ spec:
     timeout: 10m
     recreate: true
     cleanupOnFail: true
-  # Depends on having the sealed secret to un-encrypted required secrets.
+  # Depends on having the sealed secret to un-encrypted required secrets, and thanos
   dependsOn:
     - name: sealed-secrets
       namespace: kube-system
@@ -57,26 +57,17 @@ spec:
     # Disable kubeProxy whilst using Cilium as it's not deployed
     kubeProxy:
       enabled: false
+    # Disable kubeControllerManager & kubeScheduler to test stability
+    kubeControllerManager:
+      enabled: false
+    kubeScheduler:
+      enabled: false
     alertmanager:
       fullnameOverride: alertmanager
       enabled: true
       alertmanagerSpec:
         # Required for istio - https://istio.io/latest/docs/reference/config/analysis/ist0118/
         portName: http-web
-      ingress:
-        enabled: false
-        annotations:
-          kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: 'letsencrypt-prod'
-          nginx.ingress.kubernetes.io/auth-url: 'https://raspbernetes.com/oauth2/auth'
-          nginx.ingress.kubernetes.io/auth-signin: 'https://raspbernetes.com/oauth2/start?rd=$escaped_request_uri'
-        hosts:
-          - alert-manager.raspbernetes.com
-        path: /
-        tls:
-          - secretName: alert-manager.raspbernetes.com-tls
-            hosts:
-              - alert-manager.raspbernetes.com
     grafana:
       fullnameOverride: grafana
       enabled: true
@@ -85,25 +76,8 @@ spec:
         portName: http-service
       image:
         repository: grafana/grafana
-        tag: 7.3.1
-      ingress:
-        enabled: false
-        annotations:
-          kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: 'letsencrypt-prod'
-          nginx.ingress.kubernetes.io/auth-url: 'https://raspbernetes.com/oauth2/auth'
-          nginx.ingress.kubernetes.io/auth-signin: 'https://raspbernetes.com/oauth2/start?rd=$escaped_request_uri'
-        hosts:
-          - grafana.raspbernetes.com
-        path: /
-        tls:
-          - secretName: grafana.raspbernetes.com-tls
-            hosts:
-              - grafana.raspbernetes.com
+        tag: 7.3.4
       sidecar:
-        image:
-          tag: 0.1.193
-        imagePullPolicy: Always
         dashboards:
           enabled: true
           searchNamespace: ALL
@@ -217,9 +191,6 @@ spec:
           type: loki
           access: proxy
           url: http://loki.observability.svc.cluster.local:3100
-      downloadDashboardsImage:
-        repository: curlimages/curl
-        tag: 7.72.0
       # Unused because disable_login_form=true however, used for backup authentication
       admin:
         existingSecret: 'grafana-admin-creds'
@@ -274,20 +245,6 @@ spec:
           org_id: 1
     prometheus:
       fullnameOverride: prometheus
-      ingress:
-        enabled: false
-        annotations:
-          kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: 'letsencrypt-prod'
-          nginx.ingress.kubernetes.io/auth-url: 'https://raspbernetes.com/oauth2/auth'
-          nginx.ingress.kubernetes.io/auth-signin: 'https://raspbernetes.com/oauth2/start?rd=$escaped_request_uri'
-        hosts:
-          - prometheus.raspbernetes.com
-        path: /
-        tls:
-          - secretName: prometheus.raspbernetes.com-tls
-            hosts:
-              - prometheus.raspbernetes.com
       ## Settings affecting prometheusSpec
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
       ##


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Since updating to Istio there is no intention in keeping nginx configuration in the `kube-prometheus-stack` helm release resource so removing it to keep the resource easier to check and removing fields no longer required due to arm64 architecture support maintained by the upstream provider.

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All pre-commit hook validation passed successfully.
- [x] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
