### PR TITLE
Replaced dex frontend logo with correct URL.

### DIFF
--- a/cluster/network/dex/dex.yaml
+++ b/cluster/network/dex/dex.yaml
@@ -67,7 +67,7 @@ spec:
         theme: 'tectonic'
         issuer: 'Raspbernetes'
         issuerUrl: 'https://raspbernetes.com'
-        logoUrl: https://github.com/raspbernetes/docs/blob/master/website/static/img/logo.png
+        logoUrl: https://raw.githubusercontent.com/raspbernetes/docs/master/website/static/img/logo.png
       expiry:
         signingKeys: '6h'
         idTokens: '24h'


### PR DESCRIPTION
Used github raw image to correctley load raspbernetes logo.

Signed-off-by: anthr76 <hello@anthonyrabbito.com>

# Description

Currently in Dex the non raw image was being loaded. If you are seeing the logo currently it's likely it was cached by cloudflare. Current usage without raw prevents the logo from being loaded onto the dex front end.

## Checklist

- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] All pre-commit hook validation passed successfully.
- [X] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [ ] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
